### PR TITLE
Minor change in favour of inheriting MasterDetail navigation

### DIFF
--- a/samples/FreshMvvmSampleApp/FreshMvvmSampleApp/Navigation/CustomImplementedNav.cs
+++ b/samples/FreshMvvmSampleApp/FreshMvvmSampleApp/Navigation/CustomImplementedNav.cs
@@ -1,88 +1,93 @@
-﻿using System;
-using FreshMvvm;
-using Xamarin.Forms;
-using System.Collections.Generic;
+﻿using FreshMvvm;
 using System.Threading.Tasks;
+using Xamarin.Forms;
 
 namespace FreshMvvmSampleApp
 {
-	/// <summary>
-	/// This is a sample custom implemented Navigation. It combines a MasterDetail and a TabbedPage.
-	/// </summary>
-	public class CustomImplementedNav : Xamarin.Forms.MasterDetailPage, IFreshNavigationService
-	{
-		FreshTabbedNavigationContainer _tabbedNavigationPage;
-		Page _contactsPage, _quotesPage;
+    /// <summary>
+    /// This is a sample custom implemented Navigation. It combines a MasterDetail and a TabbedPage.
+    /// </summary>
+    public class CustomImplementedNav : Xamarin.Forms.MasterDetailPage, IFreshNavigationService
+    {
+        private FreshTabbedNavigationContainer _tabbedNavigationPage;
+        private Page _contactsPage, _quotesPage;
 
-		public CustomImplementedNav ()
-		{	
-			SetupTabbedPage ();
-			CreateMenuPage ("Menu");
-			RegisterNavigation ();
-		}
+        public CustomImplementedNav()
+        {
+            SetupTabbedPage();
+            CreateMenuPage("Menu");
+            RegisterNavigation();
+        }
 
-		void SetupTabbedPage()
-		{
-			_tabbedNavigationPage = new FreshTabbedNavigationContainer ();
-			_contactsPage = _tabbedNavigationPage.AddTab<ContactListPageModel> ("Contacts", "contacts.png");
-			_quotesPage = _tabbedNavigationPage.AddTab<QuoteListPageModel> ("Quotes", "document.png");
-			this.Detail = _tabbedNavigationPage;
-		}
+        private void SetupTabbedPage()
+        {
+            _tabbedNavigationPage = new FreshTabbedNavigationContainer();
+            _contactsPage = _tabbedNavigationPage.AddTab<ContactListPageModel>("Contacts", "contacts.png");
+            _quotesPage = _tabbedNavigationPage.AddTab<QuoteListPageModel>("Quotes", "document.png");
+            this.Detail = _tabbedNavigationPage;
+        }
 
-		protected void RegisterNavigation()
-		{
-			FreshIOC.Container.Register<IFreshNavigationService> (this);
-		}
+        protected void RegisterNavigation()
+        {
+            FreshIOC.Container.Register<IFreshNavigationService>(this);
+        }
 
-		protected void CreateMenuPage(string menuPageTitle)
-		{
-			var _menuPage = new ContentPage ();
-			_menuPage.Title = menuPageTitle;
-			var listView = new ListView();
+        protected void CreateMenuPage(string menuPageTitle)
+        {
+            var _menuPage = new ContentPage();
+            _menuPage.Title = menuPageTitle;
+            var listView = new ListView();
 
-			listView.ItemsSource = new string[] { "Contacts", "Quotes", "Modal Demo" };
+            listView.ItemsSource = new string[] { "Contacts", "Quotes", "Modal Demo" };
 
-			listView.ItemSelected += async (sender, args) =>
-			{
+            listView.ItemSelected += async (sender, args) =>
+            {
+                switch ((string)args.SelectedItem)
+                {
+                    case "Contacts":
+                        _tabbedNavigationPage.CurrentPage = _contactsPage;
+                        break;
 
-				switch ((string)args.SelectedItem) {
-				case "Contacts":
-					_tabbedNavigationPage.CurrentPage = _contactsPage;
-					break;
-				case "Quotes":
-					_tabbedNavigationPage.CurrentPage = _quotesPage;
-					break;
-				case "Modal Demo":
-                    var modalPage = FreshPageModelResolver.ResolvePageModel<ModalPageModel>();
-					await PushPage(modalPage, null, true);
-					break;
-				default:
-				break;
-				}
+                    case "Quotes":
+                        _tabbedNavigationPage.CurrentPage = _quotesPage;
+                        break;
 
-				IsPresented = false;
-			};
+                    case "Modal Demo":
+                        var modalPage = FreshPageModelResolver.ResolvePageModel<ModalPageModel>();
+                        await PushPage(modalPage, null, true);
+                        break;
 
-			_menuPage.Content = listView;
+                    default:
+                        break;
+                }
 
-			Master = new NavigationPage(_menuPage) { Title = "Menu" };
-		}
+                IsPresented = false;
+            };
 
-        public virtual async Task PushPage (Xamarin.Forms.Page page, FreshBasePageModel model, bool modal = false, bool animated = true)
-		{
-			if (modal)
-                await Navigation.PushModalAsync (new NavigationPage(page), animated);
-			else
-                await ((NavigationPage)_tabbedNavigationPage.CurrentPage).PushAsync (page, animated); 
-		}
+            _menuPage.Content = listView;
 
-        public virtual async Task PopPage (bool modal = false, bool animate = true)
-		{
-			if (modal)
-				await Navigation.PopModalAsync ();
-			else
-				await ((NavigationPage)_tabbedNavigationPage.CurrentPage).PopAsync (); 
-		}
-	}
+            Master = new NavigationPage(_menuPage) { Title = "Menu" };
+        }
+
+        public async Task PopToRoot(bool animate = true)
+        {
+            await (Detail as NavigationPage).PopToRootAsync(animate);
+        }
+
+        public virtual async Task PushPage(Xamarin.Forms.Page page, FreshBasePageModel model, bool modal = false, bool animated = true)
+        {
+            if (modal)
+                await Navigation.PushModalAsync(new NavigationPage(page), animated);
+            else
+                await ((NavigationPage)_tabbedNavigationPage.CurrentPage).PushAsync(page, animated);
+        }
+
+        public virtual async Task PopPage(bool modal = false, bool animate = true)
+        {
+            if (modal)
+                await Navigation.PopModalAsync();
+            else
+                await ((NavigationPage)_tabbedNavigationPage.CurrentPage).PopAsync();
+        }
+    }
 }
-

--- a/src/FreshMvvm/FreshMasterDetailNavigationContainer.cs
+++ b/src/FreshMvvm/FreshMasterDetailNavigationContainer.cs
@@ -1,58 +1,63 @@
-﻿using System;
+﻿using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Threading.Tasks;
 using Xamarin.Forms;
-using System.Collections.Generic;
-using System.Collections.ObjectModel;
 
 namespace FreshMvvm
 {
     public class FreshMasterDetailNavigationContainer : Xamarin.Forms.MasterDetailPage, IFreshNavigationService
     {
-        Dictionary<string, Page> _pages = new Dictionary<string, Page> ();
-        ContentPage _menuPage;
-        ObservableCollection<string> _pageNames = new ObservableCollection<string> ();
+        private Dictionary<string, Page> _pages = new Dictionary<string, Page>();
+        private ContentPage _menuPage;
+        private ObservableCollection<string> _pageNames = new ObservableCollection<string>();
 
-        public FreshMasterDetailNavigationContainer ()
-        {			
+        protected Dictionary<string, Page> Pages { get { return _pages; } }
+
+        protected ObservableCollection<string> PageNames { get { return _pageNames; } }
+
+        public FreshMasterDetailNavigationContainer()
+        {
         }
 
-        public void Init (string menuTitle)
+        public void Init(string menuTitle)
         {
-            CreateMenuPage (menuTitle);
-            RegisterNavigation ();
+            CreateMenuPage(menuTitle);
+            RegisterNavigation();
         }
 
-        protected virtual void RegisterNavigation ()
+        protected virtual void RegisterNavigation()
         {
-            FreshIOC.Container.Register<IFreshNavigationService> (this);
+            FreshIOC.Container.Register<IFreshNavigationService>(this);
         }
 
-        public virtual void AddPage<T> (string title, object data = null) where T : FreshBasePageModel
+        public virtual void AddPage<T>(string title, object data = null) where T : FreshBasePageModel
         {
-            var page = FreshPageModelResolver.ResolvePageModel<T> (data);
-            var navigationContainer = CreateContainerPage (page);
-            _pages.Add (title, navigationContainer);
-            _pageNames.Add (title);
+            var page = FreshPageModelResolver.ResolvePageModel<T>(data);
+            var navigationContainer = CreateContainerPage(page);
+            _pages.Add(title, navigationContainer);
+            _pageNames.Add(title);
             if (_pages.Count == 1)
                 Detail = navigationContainer;
         }
 
-        protected virtual Page CreateContainerPage (Page page)
+        protected virtual Page CreateContainerPage(Page page)
         {
-            return new NavigationPage (page);
+            return new NavigationPage(page);
         }
 
-        protected virtual void CreateMenuPage (string menuPageTitle)
+        protected virtual void CreateMenuPage(string menuPageTitle)
         {
-            _menuPage = new ContentPage ();
+            _menuPage = new ContentPage();
             _menuPage.Title = menuPageTitle;
-            var listView = new ListView ();
+            var listView = new ListView();
 
             listView.ItemsSource = _pageNames;
 
-            listView.ItemSelected += (sender, args) => {
-                if (_pages.ContainsKey ((string)args.SelectedItem)) {
-                    Detail = _pages [(string)args.SelectedItem];
+            listView.ItemSelected += (sender, args) =>
+            {
+                if (_pages.ContainsKey((string)args.SelectedItem))
+                {
+                    Detail = _pages[(string)args.SelectedItem];
                 }
 
                 IsPresented = false;
@@ -60,29 +65,28 @@ namespace FreshMvvm
 
             _menuPage.Content = listView;
 
-            Master = new NavigationPage (_menuPage) { Title = "Menu" };
+            Master = new NavigationPage(_menuPage) { Title = "Menu" };
         }
 
-        public async Task PushPage (Page page, FreshBasePageModel model, bool modal = false, bool animate = true)
-             {
-			if (modal)
-				await Navigation.PushModalAsync (new NavigationPage (page));
-			else
-				await (Detail as NavigationPage).PushAsync (page, animate); //TODO: make this better
-		}
-
-		public async Task PopPage (bool modal = false, bool animate = true)
-		{
-            if (modal)
-				await Navigation.PopModalAsync (animate);
-			else
-				await (Detail as NavigationPage).PopAsync (animate); //TODO: make this better
-		}
-
-        public async Task PopToRoot (bool animate = true)
+        public async Task PushPage(Page page, FreshBasePageModel model, bool modal = false, bool animate = true)
         {
-            await (Detail as NavigationPage).PopToRootAsync (animate);
+            if (modal)
+                await Navigation.PushModalAsync(new NavigationPage(page));
+            else
+                await (Detail as NavigationPage).PushAsync(page, animate); //TODO: make this better
+        }
+
+        public async Task PopPage(bool modal = false, bool animate = true)
+        {
+            if (modal)
+                await Navigation.PopModalAsync(animate);
+            else
+                await (Detail as NavigationPage).PopAsync(animate); //TODO: make this better
+        }
+
+        public async Task PopToRoot(bool animate = true)
+        {
+            await (Detail as NavigationPage).PopToRootAsync(animate);
         }
     }
 }
-


### PR DESCRIPTION
Fixed CustomImplementedNav (wasn't implementing new interface PopToRoot method) and exposed private properties in FreshMasterDetailNavigationContainer so that it's better inheritable.

I wanted the MasterDetail navigation as implemented but wasn't able to style it to my needs. By exposing the page collections I can use these to feed my custom Page for the menu.