### PR TITLE
Redundant async/awaits in navigation

### DIFF
--- a/src/FreshMvvm/FreshMasterDetailNavigationContainer.cs
+++ b/src/FreshMvvm/FreshMasterDetailNavigationContainer.cs
@@ -83,16 +83,16 @@ namespace FreshMvvm
 
         public Task PushPage (Page page, FreshBasePageModel model, bool modal = false, bool animate = true)
         {
-			if (modal)
+            if (modal)
                 return Navigation.PushModalAsync (new NavigationPage (page));
-			return (Detail as NavigationPage).PushAsync (page, animate); //TODO: make this better
+            return (Detail as NavigationPage).PushAsync (page, animate); //TODO: make this better
 		}
 
 		public Task PopPage (bool modal = false, bool animate = true)
 		{
             if (modal)
-				return Navigation.PopModalAsync (animate);
-			return (Detail as NavigationPage).PopAsync (animate); //TODO: make this better
+                return Navigation.PopModalAsync (animate);
+            return (Detail as NavigationPage).PopAsync (animate); //TODO: make this better
 		}
 
         public Task PopToRoot (bool animate = true)

--- a/src/FreshMvvm/FreshMasterDetailNavigationContainer.cs
+++ b/src/FreshMvvm/FreshMasterDetailNavigationContainer.cs
@@ -81,25 +81,23 @@ namespace FreshMvvm
             Master = navPage;
         }
 
-        public async Task PushPage (Page page, FreshBasePageModel model, bool modal = false, bool animate = true)
-             {
+        public Task PushPage (Page page, FreshBasePageModel model, bool modal = false, bool animate = true)
+        {
 			if (modal)
-				await Navigation.PushModalAsync (new NavigationPage (page));
-			else
-				await (Detail as NavigationPage).PushAsync (page, animate); //TODO: make this better
+                return Navigation.PushModalAsync (new NavigationPage (page));
+			return (Detail as NavigationPage).PushAsync (page, animate); //TODO: make this better
 		}
 
-		public async Task PopPage (bool modal = false, bool animate = true)
+		public Task PopPage (bool modal = false, bool animate = true)
 		{
             if (modal)
-				await Navigation.PopModalAsync (animate);
-			else
-				await (Detail as NavigationPage).PopAsync (animate); //TODO: make this better
+				return Navigation.PopModalAsync (animate);
+			return (Detail as NavigationPage).PopAsync (animate); //TODO: make this better
 		}
 
-        public async Task PopToRoot (bool animate = true)
+        public Task PopToRoot (bool animate = true)
         {
-            await (Detail as NavigationPage).PopToRootAsync (animate);
+            return (Detail as NavigationPage).PopToRootAsync (animate);
         }
 
         public string NavigationServiceName { get; private set; }

--- a/src/FreshMvvm/FreshNavigationContainer.cs
+++ b/src/FreshMvvm/FreshNavigationContainer.cs
@@ -33,25 +33,23 @@ namespace FreshMvvm
             return new NavigationPage (page);
         }
 
-		public async virtual Task PushPage (Xamarin.Forms.Page page, FreshBasePageModel model, bool modal = false, bool animate = true)
+		public virtual Task PushPage (Xamarin.Forms.Page page, FreshBasePageModel model, bool modal = false, bool animate = true)
         {
             if (modal)
-				await Navigation.PushModalAsync (CreateContainerPage (page), animate);
-            else
-				await Navigation.PushAsync (page, animate);
+				return Navigation.PushModalAsync (CreateContainerPage (page), animate);
+            return Navigation.PushAsync (page, animate);
         }
 
-		public async virtual Task PopPage (bool modal = false, bool animate = true)
+		public virtual Task PopPage (bool modal = false, bool animate = true)
         {
             if (modal)
-				await Navigation.PopModalAsync (animate);
-            else
-				await Navigation.PopAsync (animate);
+				return Navigation.PopModalAsync (animate);
+            return Navigation.PopAsync (animate);
         }
 
-        public async Task PopToRoot (bool animate = true)
+        public Task PopToRoot (bool animate = true)
         {
-            await Navigation.PopToRootAsync (animate); 
+            return Navigation.PopToRootAsync (animate); 
         }
 
         public string NavigationServiceName { get; private set; }

--- a/src/FreshMvvm/FreshNavigationContainer.cs
+++ b/src/FreshMvvm/FreshNavigationContainer.cs
@@ -36,14 +36,14 @@ namespace FreshMvvm
 		public virtual Task PushPage (Xamarin.Forms.Page page, FreshBasePageModel model, bool modal = false, bool animate = true)
         {
             if (modal)
-				return Navigation.PushModalAsync (CreateContainerPage (page), animate);
+                return Navigation.PushModalAsync (CreateContainerPage (page), animate);
             return Navigation.PushAsync (page, animate);
         }
 
 		public virtual Task PopPage (bool modal = false, bool animate = true)
         {
             if (modal)
-				return Navigation.PopModalAsync (animate);
+                return Navigation.PopModalAsync (animate);
             return Navigation.PopAsync (animate);
         }
 

--- a/src/FreshMvvm/FreshTabbedNavigationContainer.cs
+++ b/src/FreshMvvm/FreshTabbedNavigationContainer.cs
@@ -47,25 +47,23 @@ namespace FreshMvvm
             return new NavigationPage (page);
         }
 
-		public async System.Threading.Tasks.Task PushPage (Xamarin.Forms.Page page, FreshBasePageModel model, bool modal = false, bool animate = true)
+		public System.Threading.Tasks.Task PushPage (Xamarin.Forms.Page page, FreshBasePageModel model, bool modal = false, bool animate = true)
         {
             if (modal)
-                await this.CurrentPage.Navigation.PushModalAsync (CreateContainerPage (page));
-            else
-                await this.CurrentPage.Navigation.PushAsync (page);
+                return this.CurrentPage.Navigation.PushModalAsync (CreateContainerPage (page));
+            return this.CurrentPage.Navigation.PushAsync (page);
         }
 
-		public async System.Threading.Tasks.Task PopPage (bool modal = false, bool animate = true)
+		public System.Threading.Tasks.Task PopPage (bool modal = false, bool animate = true)
         {
             if (modal)
-                await this.CurrentPage.Navigation.PopModalAsync (animate);
-            else
-                await this.CurrentPage.Navigation.PopAsync (animate);
+                return this.CurrentPage.Navigation.PopModalAsync (animate);
+            return this.CurrentPage.Navigation.PopAsync (animate);
         }
 
-        public async Task PopToRoot (bool animate = true)
+        public Task PopToRoot (bool animate = true)
         {
-            await this.CurrentPage.Navigation.PopToRootAsync (animate);
+            return this.CurrentPage.Navigation.PopToRootAsync (animate);
         }
 
         public string NavigationServiceName { get; private set; }


### PR DESCRIPTION
Noticed that all navigation containers use async/awaits in push and pop methods. We can remove them and return Tasks from Xamarin.Forms navigation directly.
P.S. Thanks for the framework! Will definitely try it on one of my projects :-)