### PR TITLE
Allow ViewModel suffix for page models

### DIFF
--- a/src/FreshMvvm/FreshPageModelResolver.cs
+++ b/src/FreshMvvm/FreshPageModelResolver.cs
@@ -31,7 +31,7 @@ namespace FreshMvvm
 
         public static Page ResolvePageModel (Type type, object data, FreshBasePageModel pageModel)
         {
-            var name = type.AssemblyQualifiedName.Replace ("Model", string.Empty);
+            var name = GetPageTypeName (type);
             var pageType = Type.GetType (name);
             if (pageType == null)
                 throw new Exception (name + " not found");
@@ -45,6 +45,13 @@ namespace FreshMvvm
             page.BindingContext = pageModel;
 
             return page;
+        }
+
+        private static string GetPageTypeName (Type pageModelType)
+        {
+            return pageModelType.AssemblyQualifiedName
+                       .Replace ("PageModel", "Page")
+                       .Replace ("ViewModel", "Page");
         }
 
     }


### PR DESCRIPTION
I propose to extend FreshMvvm naming convention and allow not only "PageModel", but "ViewModel" suffix for page models. This just looks more standard for MVVM frameworks and will simplify legacy code refactoring.