### PR TITLE
Update FreshPageModelMapper.cs

### DIFF
--- a/src/FreshMvvm/FreshPageModelMapper.cs
+++ b/src/FreshMvvm/FreshPageModelMapper.cs
@@ -8,7 +8,7 @@ namespace FreshMvvm
         {
             return pageModelType.AssemblyQualifiedName
                 .Replace ("PageModel", "Page")
-                .Replace ("ViewModel", "Page");
+                .Replace ("ViewModel", "View");
         }
     }
 }


### PR DESCRIPTION
Hi,

i think its useful if the FreshPageModelMapper returns "View" instead of "Page" if the ViewModel Name ist "ViewModel" instead of "PageModel".

What do you think about it?