### PR TITLE
add *ViewModel -> *View resolution as fallback

### DIFF
--- a/src/FreshMvvm/FreshMvvm.csproj
+++ b/src/FreshMvvm/FreshMvvm.csproj
@@ -31,6 +31,7 @@
     <ConsolePause>false</ConsolePause>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="FreshViewModelWrapper.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="FreshBasePageModel.cs" />
     <Compile Include="FreshIOC.cs" />

--- a/src/FreshMvvm/FreshViewModelWrapper.cs
+++ b/src/FreshMvvm/FreshViewModelWrapper.cs
@@ -1,0 +1,15 @@
+﻿using System;
+
+namespace FreshMvvm
+{
+    public class FreshViewModelMapper : IFreshPageModelMapper
+    {
+        public string GetPageTypeName(Type pageModelType)
+        {
+            return pageModelType.AssemblyQualifiedName
+                .Replace ("PageModel", "View")
+                .Replace ("ViewModel", "View");
+        }
+    }
+}
+


### PR DESCRIPTION
add FreshViewModelMapper for fallback type mapping
add FindPageModelMapper() to FreshPageModelResolver to decide (once!) which of the conventions and mappers should be used
add backing field _pageModelMapper to PageModelMapper property and _isPageModelFound field to prevent overwriting the user's instance if she set a custom IFreshPageModelMapper