### PR TITLE
easily add tabs through an interface

### DIFF
--- a/src/FreshMvvm/FreshMvvm.csproj
+++ b/src/FreshMvvm/FreshMvvm.csproj
@@ -10,6 +10,7 @@
     <AssemblyName>FreshMvvm</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <TargetFrameworkProfile>Profile78</TargetFrameworkProfile>
+    <ReleaseVersion>2.1.0</ReleaseVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -49,6 +50,7 @@
     <Compile Include="IFreshPageModelMapper.cs" />
     <Compile Include="FreshPageModelMapper.cs" />
     <Compile Include="FreshTabbedFONavigationContainer.cs" />
+    <Compile Include="ISupportTabNavigation.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
   <Import Project="..\packages\Xamarin.Forms.2.0.1.6505\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.targets" Condition="Exists('..\packages\Xamarin.Forms.2.0.1.6505\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.targets')" />

--- a/src/FreshMvvm/FreshTabbedFONavigationContainer.cs
+++ b/src/FreshMvvm/FreshTabbedFONavigationContainer.cs
@@ -6,107 +6,119 @@ using System.Linq;
 
 namespace FreshMvvm
 {
-    /// <summary>
-    /// This Tabbed navigation container for when you only want the tabs to appear on the first page and then push to a second page without tabs
-    /// </summary>
-    public class FreshTabbedFONavigationContainer : NavigationPage, IFreshNavigationService
-    {
-        TabbedPage _innerTabbedPage;
-        public TabbedPage FirstTabbedPage { get { return _innerTabbedPage; } }
-        List<Page> _tabs = new List<Page>();
-        public IEnumerable<Page> TabbedPages { get { return _tabs; } }
+	/// <summary>
+	/// This Tabbed navigation container for when you only want the tabs to appear on the first page and then push to a second page without tabs
+	/// </summary>
+	public class FreshTabbedFONavigationContainer : NavigationPage, IFreshNavigationService
+	{
+		TabbedPage _innerTabbedPage;
+		public TabbedPage FirstTabbedPage { get { return _innerTabbedPage; } }
+		List<Page> _tabs = new List<Page>();
+		public IEnumerable<Page> TabbedPages { get { return _tabs; } }
 
-        public FreshTabbedFONavigationContainer (string titleOfFirstTab) : this(titleOfFirstTab, Constants.DefaultNavigationServiceName)
-        {               
-        }
+		public FreshTabbedFONavigationContainer(string titleOfFirstTab) : this(titleOfFirstTab, Constants.DefaultNavigationServiceName)
+		{
+		}
 
-        public FreshTabbedFONavigationContainer(string titleOfFirstTab, string navigationServiceName) : base(new TabbedPage())
-        {           
-            NavigationServiceName = navigationServiceName;
-            RegisterNavigation();
-            _innerTabbedPage = (TabbedPage)this.CurrentPage;
-            _innerTabbedPage.Title = titleOfFirstTab;
-        }
+		public FreshTabbedFONavigationContainer(string titleOfFirstTab, string navigationServiceName) : base(new TabbedPage())
+		{
+			NavigationServiceName = navigationServiceName;
+			RegisterNavigation();
+			_innerTabbedPage = (TabbedPage)this.CurrentPage;
+			_innerTabbedPage.Title = titleOfFirstTab;
+		}
 
-        protected void RegisterNavigation ()
-        {
-            FreshIOC.Container.Register<IFreshNavigationService> (this, NavigationServiceName);
-        }
+		protected void RegisterNavigation()
+		{
+			FreshIOC.Container.Register<IFreshNavigationService>(this, NavigationServiceName);
+		}
 
-        public virtual Page AddTab<T> (string title, string icon, object data = null) where T : FreshBasePageModel
-        {
-            var page = FreshPageModelResolver.ResolvePageModel<T> (data);
-            page.GetModel ().CurrentNavigationServiceName = NavigationServiceName;
-            _tabs.Add (page);
-            var container = CreateContainerPageSafe (page);
-            container.Title = title;
-            if (!string.IsNullOrWhiteSpace(icon))
-                container.Icon = icon;
-            _innerTabbedPage.Children.Add (container);
-            return container;
-        }
+		public virtual Page AddTab<T>(string title, string icon, object data = null) where T : FreshBasePageModel
+		{
+			var page = FreshPageModelResolver.ResolvePageModel<T>(data);
+			return AddTab(page, title, icon);
+		}
 
-        internal Page CreateContainerPageSafe (Page page)
-        {
-            if (page is NavigationPage || page is MasterDetailPage || page is TabbedPage)
-                return page;
+		Page AddTab(Page page, string title, string icon)
+		{
+			page.GetModel().CurrentNavigationServiceName = NavigationServiceName;
+			_tabs.Add(page);
+			var navigationContainer = CreateContainerPageSafe(page);
+			navigationContainer.Title = title;
+			if (!string.IsNullOrWhiteSpace(icon))
+				navigationContainer.Icon = icon;
+			_innerTabbedPage.Children.Add(navigationContainer);
+			return navigationContainer;
+		}
 
-            return CreateContainerPage(page);
-        }
+		public virtual Page AddTab<T>(object data = null) where T : FreshBasePageModel, ISupportTabNavigation
+		{
+			var page = FreshPageModelResolver.ResolvePageModel<T>(data);
+			var model = page.GetModel() as ISupportTabNavigation;
+			return AddTab(page, model.Title, model.Icon);
+		}
 
-        protected virtual Page CreateContainerPage (Page page)
-        {
-            return page;
-        }
+		internal Page CreateContainerPageSafe(Page page)
+		{
+			if (page is NavigationPage || page is MasterDetailPage || page is TabbedPage)
+				return page;
 
-        public System.Threading.Tasks.Task PushPage (Xamarin.Forms.Page page, FreshBasePageModel model, bool modal = false, bool animate = true)
-        {
-            if (modal)
-                return this.Navigation.PushModalAsync (CreateContainerPageSafe (page));
-            return this.Navigation.PushAsync (page);
-        }
+			return CreateContainerPage(page);
+		}
 
-        public System.Threading.Tasks.Task PopPage (bool modal = false, bool animate = true)
-        {
-            if (modal)
-                return this.Navigation.PopModalAsync (animate);
-            return this.Navigation.PopAsync (animate);
-        }
+		protected virtual Page CreateContainerPage(Page page)
+		{
+			return page;
+		}
 
-        public Task PopToRoot (bool animate = true)
-        {
-            return this.Navigation.PopToRootAsync (animate);
-        }
+		public System.Threading.Tasks.Task PushPage(Xamarin.Forms.Page page, FreshBasePageModel model, bool modal = false, bool animate = true)
+		{
+			if (modal)
+				return this.Navigation.PushModalAsync(CreateContainerPageSafe(page));
+			return this.Navigation.PushAsync(page);
+		}
 
-        public string NavigationServiceName { get; private set; }
+		public System.Threading.Tasks.Task PopPage(bool modal = false, bool animate = true)
+		{
+			if (modal)
+				return this.Navigation.PopModalAsync(animate);
+			return this.Navigation.PopAsync(animate);
+		}
 
-        public void NotifyChildrenPageWasPopped()
-        {
-            foreach (var page in _innerTabbedPage.Children)
-            {
-                if (page is NavigationPage)
-                    ((NavigationPage)page).NotifyAllChildrenPopped();
-            }
-        }
+		public Task PopToRoot(bool animate = true)
+		{
+			return this.Navigation.PopToRootAsync(animate);
+		}
 
-        public Task<FreshBasePageModel> SwitchSelectedRootPageModel<T>() where T : FreshBasePageModel
-        {
-            if (this.CurrentPage == _innerTabbedPage)
-            {
-                var page = _tabs.FindIndex(o => o.GetModel().GetType().FullName == typeof(T).FullName);
-                if (page > -1)
-                {
-                    _innerTabbedPage.CurrentPage = this._innerTabbedPage.Children[page];
-                    return Task.FromResult(_innerTabbedPage.CurrentPage.GetModel());
-                }
-            }
-            else
-            {
-                throw new Exception("Cannot switch tabs when the tab screen is not visible");
-            }
+		public string NavigationServiceName { get; private set; }
 
-            return null;
-        }
-    }
+		public void NotifyChildrenPageWasPopped()
+		{
+			foreach (var page in _innerTabbedPage.Children)
+			{
+				if (page is NavigationPage)
+					((NavigationPage)page).NotifyAllChildrenPopped();
+			}
+		}
+
+		public Task<FreshBasePageModel> SwitchSelectedRootPageModel<T>() where T : FreshBasePageModel
+		{
+			if (this.CurrentPage == _innerTabbedPage)
+			{
+				var page = _tabs.FindIndex(o => o.GetModel().GetType().FullName == typeof(T).FullName);
+				if (page > -1)
+				{
+					_innerTabbedPage.CurrentPage = this._innerTabbedPage.Children[page];
+					return Task.FromResult(_innerTabbedPage.CurrentPage.GetModel());
+				}
+			}
+			else
+			{
+				throw new Exception("Cannot switch tabs when the tab screen is not visible");
+			}
+
+			return null;
+		}
+	}
 }
 

--- a/src/FreshMvvm/FreshTabbedNavigationContainer.cs
+++ b/src/FreshMvvm/FreshTabbedNavigationContainer.cs
@@ -6,97 +6,109 @@ using System.Linq;
 
 namespace FreshMvvm
 {
-    public class FreshTabbedNavigationContainer : TabbedPage, IFreshNavigationService
-    {
-        List<Page> _tabs = new List<Page>();
-        public IEnumerable<Page> TabbedPages { get { return _tabs; } }
+	public class FreshTabbedNavigationContainer : TabbedPage, IFreshNavigationService
+	{
+		List<Page> _tabs = new List<Page>();
+		public IEnumerable<Page> TabbedPages { get { return _tabs; } }
 
-        public FreshTabbedNavigationContainer () : this(Constants.DefaultNavigationServiceName)
-        {				
-            
-        }
+		public FreshTabbedNavigationContainer() : this(Constants.DefaultNavigationServiceName)
+		{
 
-        public FreshTabbedNavigationContainer(string navigationServiceName)
-        {
-            NavigationServiceName = navigationServiceName;
-            RegisterNavigation ();
-        }
+		}
 
-        protected void RegisterNavigation ()
-        {
-            FreshIOC.Container.Register<IFreshNavigationService> (this, NavigationServiceName);
-        }
+		public FreshTabbedNavigationContainer(string navigationServiceName)
+		{
+			NavigationServiceName = navigationServiceName;
+			RegisterNavigation();
+		}
 
-        public virtual Page AddTab<T> (string title, string icon, object data = null) where T : FreshBasePageModel
-        {
-            var page = FreshPageModelResolver.ResolvePageModel<T> (data);
-            page.GetModel ().CurrentNavigationServiceName = NavigationServiceName;
-            _tabs.Add (page);
-            var navigationContainer = CreateContainerPageSafe (page);
-            navigationContainer.Title = title;
-            if (!string.IsNullOrWhiteSpace(icon))
-                navigationContainer.Icon = icon;
-            Children.Add (navigationContainer);
-            return navigationContainer;
-        }
+		protected void RegisterNavigation()
+		{
+			FreshIOC.Container.Register<IFreshNavigationService>(this, NavigationServiceName);
+		}
 
-        internal Page CreateContainerPageSafe (Page page)
-        {
-            if (page is NavigationPage || page is MasterDetailPage || page is TabbedPage)
-                return page;
+		public virtual Page AddTab<T>(string title, string icon, object data = null) where T : FreshBasePageModel
+		{
+			var page = FreshPageModelResolver.ResolvePageModel<T>(data);
+			return AddTab(page, title, icon);
+		}
 
-            return CreateContainerPage(page);
-        }
+		Page AddTab(Page page, string title, string icon)
+		{
+			page.GetModel().CurrentNavigationServiceName = NavigationServiceName;
+			_tabs.Add(page);
+			var navigationContainer = CreateContainerPageSafe(page);
+			navigationContainer.Title = title;
+			if (!string.IsNullOrWhiteSpace(icon))
+				navigationContainer.Icon = icon;
+			Children.Add(navigationContainer);
+			return navigationContainer;
+		}
 
-        protected virtual Page CreateContainerPage (Page page)
-        {
-            return new NavigationPage (page);
-        }
+		public virtual Page AddTab<T>(object data = null) where T : FreshBasePageModel, ISupportTabNavigation
+		{
+			var page = FreshPageModelResolver.ResolvePageModel<T>(data);
+			var model = page.GetModel() as ISupportTabNavigation;
+			return AddTab(page, model.Title, model.Icon);
+		}
 
-		public System.Threading.Tasks.Task PushPage (Xamarin.Forms.Page page, FreshBasePageModel model, bool modal = false, bool animate = true)
-        {
-            if (modal)
-                return this.CurrentPage.Navigation.PushModalAsync (CreateContainerPageSafe (page));
-            return this.CurrentPage.Navigation.PushAsync (page);
-        }
+		internal Page CreateContainerPageSafe(Page page)
+		{
+			if (page is NavigationPage || page is MasterDetailPage || page is TabbedPage)
+				return page;
 
-		public System.Threading.Tasks.Task PopPage (bool modal = false, bool animate = true)
-        {
-            if (modal)
-                return this.CurrentPage.Navigation.PopModalAsync (animate);
-            return this.CurrentPage.Navigation.PopAsync (animate);
-        }
+			return CreateContainerPage(page);
+		}
 
-        public Task PopToRoot (bool animate = true)
-        {
-            return this.CurrentPage.Navigation.PopToRootAsync (animate);
-        }
+		protected virtual Page CreateContainerPage(Page page)
+		{
+			return new NavigationPage(page);
+		}
 
-        public string NavigationServiceName { get; private set; }
+		public System.Threading.Tasks.Task PushPage(Xamarin.Forms.Page page, FreshBasePageModel model, bool modal = false, bool animate = true)
+		{
+			if (modal)
+				return this.CurrentPage.Navigation.PushModalAsync(CreateContainerPageSafe(page));
+			return this.CurrentPage.Navigation.PushAsync(page);
+		}
 
-        public void NotifyChildrenPageWasPopped()
-        {
-            foreach (var page in this.Children)
-            {
-                if (page is NavigationPage)
-                    ((NavigationPage)page).NotifyAllChildrenPopped();
-            }
-        }
-            
-        public Task<FreshBasePageModel> SwitchSelectedRootPageModel<T>() where T : FreshBasePageModel
-        {
-            var page = _tabs.FindIndex(o => o.GetModel().GetType().FullName == typeof(T).FullName);
+		public System.Threading.Tasks.Task PopPage(bool modal = false, bool animate = true)
+		{
+			if (modal)
+				return this.CurrentPage.Navigation.PopModalAsync(animate);
+			return this.CurrentPage.Navigation.PopAsync(animate);
+		}
 
-            if (page > -1)
-            {
-                CurrentPage = this.Children[page];
-                var topOfStack = CurrentPage.Navigation.NavigationStack.LastOrDefault();
-                if (topOfStack != null)
-                    return Task.FromResult(topOfStack.GetModel());
+		public Task PopToRoot(bool animate = true)
+		{
+			return this.CurrentPage.Navigation.PopToRootAsync(animate);
+		}
 
-            }
-            return null;
-        }
-    }
+		public string NavigationServiceName { get; private set; }
+
+		public void NotifyChildrenPageWasPopped()
+		{
+			foreach (var page in this.Children)
+			{
+				if (page is NavigationPage)
+					((NavigationPage)page).NotifyAllChildrenPopped();
+			}
+		}
+
+		public Task<FreshBasePageModel> SwitchSelectedRootPageModel<T>() where T : FreshBasePageModel
+		{
+			var page = _tabs.FindIndex(o => o.GetModel().GetType().FullName == typeof(T).FullName);
+
+			if (page > -1)
+			{
+				CurrentPage = this.Children[page];
+				var topOfStack = CurrentPage.Navigation.NavigationStack.LastOrDefault();
+				if (topOfStack != null)
+					return Task.FromResult(topOfStack.GetModel());
+
+			}
+			return null;
+		}
+	}
 }
 

--- a/src/FreshMvvm/ISupportTabNavigation.cs
+++ b/src/FreshMvvm/ISupportTabNavigation.cs
@@ -1,0 +1,8 @@
+﻿namespace FreshMvvm
+{
+	public interface ISupportTabNavigation
+	{
+		string Title { get; }
+		string Icon { get; }
+	}
+}


### PR DESCRIPTION
Simply implement the interface `ISupportTabNavigation` on the `PageModel` and use `tabNavContainer.AddTab<YourPageModel>()` to add the tab to the container. No breaking changes, the current way of adding tabs is still included.
