### PR TITLE
Added missing IPageModelCoreMethods method implementations to MockPageModelCoreMethods.cs.

### DIFF
--- a/samples/FreshMvvmSampleApp/iOS/FreshMvvmSampleApp.iOS.csproj
+++ b/samples/FreshMvvmSampleApp/iOS/FreshMvvmSampleApp.iOS.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -8,7 +8,7 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>FreshMvvmSampleApp.iOS</RootNamespace>
     <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
-    <AssemblyName>FreshMvvmSampleApp.iOS</AssemblyName>
+    <AssemblyName>FreshMvvmSampleAppiOS</AssemblyName>
     <ReleaseVersion>2.1.0</ReleaseVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhoneSimulator' ">

--- a/src/FreshMvvm.Tests/Mocks/MockPageModelCoreMethods.cs
+++ b/src/FreshMvvm.Tests/Mocks/MockPageModelCoreMethods.cs
@@ -1,15 +1,11 @@
 ﻿using System;
 using System.Threading.Tasks;
+using Xamarin.Forms;
 
 namespace FreshMvvm.Tests.Mocks
 {
-    class MockPageModelCoreMethods : IPageModelCoreMethods
+	class MockPageModelCoreMethods : IPageModelCoreMethods
 	{
-        public void SwitchOutRootNavigation(string navigationServiceName)
-        {
-            throw new NotImplementedException();
-        }
-
 		public void BatchBegin()
 		{
 			throw new NotImplementedException();
@@ -35,25 +31,15 @@ namespace FreshMvvm.Tests.Mocks
 			throw new NotImplementedException();
 		}
 
-        public Task PushPageModel<T, TPage>(object data, bool modal = false) where T : FreshBasePageModel where TPage : Xamarin.Forms.Page
-        {
-            throw new NotImplementedException();
-        }
+		public Task PopModalNavigationService()
+		{
+			throw new NotImplementedException();
+		}
 
-        public Task PushPageModel<T, TPage>() where T : FreshBasePageModel where TPage : Xamarin.Forms.Page
-        {
-            throw new NotImplementedException();
-        }
-
-        public Task PushNewNavigationServiceModal(FreshTabbedNavigationContainer tabbedNavigationContainer, FreshBasePageModel basePageModel = null)
-        {
-            throw new NotImplementedException();
-        }
-
-        public Task PushNewNavigationServiceModal(FreshMasterDetailNavigationContainer masterDetailContainer, FreshBasePageModel basePageModel = null)
-        {
-            throw new NotImplementedException();
-        }
+		public Task PopModalNavigationService(bool animate = true)
+		{
+			throw new NotImplementedException();
+		}
 
 		public Task PopPageModel(bool modal = false)
 		{
@@ -65,7 +51,67 @@ namespace FreshMvvm.Tests.Mocks
 			throw new NotImplementedException();
 		}
 
+		public Task PopPageModel(bool modal = false, bool animate = true)
+		{
+			throw new NotImplementedException();
+		}
+
+		public Task PopPageModel(object data, bool modal = false, bool animate = true)
+		{
+			throw new NotImplementedException();
+		}
+
 		public Task PopToRoot(bool animate)
+		{
+			throw new NotImplementedException();
+		}
+
+		public Task PushNewNavigationServiceModal(FreshTabbedNavigationContainer tabbedNavigationContainer, FreshBasePageModel basePageModel = null)
+		{
+			throw new NotImplementedException();
+		}
+
+		public Task PushNewNavigationServiceModal(FreshMasterDetailNavigationContainer masterDetailContainer, FreshBasePageModel basePageModel = null)
+		{
+			throw new NotImplementedException();
+		}
+
+		public Task PushNewNavigationServiceModal(IFreshNavigationService newNavigationService, FreshBasePageModel[] basePageModels)
+		{
+			throw new NotImplementedException();
+		}
+
+		public Task PushNewNavigationServiceModal(FreshTabbedNavigationContainer tabbedNavigationContainer)
+		{
+			throw new NotImplementedException();
+		}
+
+		public Task PushNewNavigationServiceModal(FreshMasterDetailNavigationContainer masterDetailContainer)
+		{
+			throw new NotImplementedException();
+		}
+
+		public Task PushNewNavigationServiceModal(IFreshNavigationService newNavigationService, FreshBasePageModel basePageModels)
+		{
+			throw new NotImplementedException();
+		}
+
+		public Task PushNewNavigationServiceModal(IFreshNavigationService newNavigationService, FreshBasePageModel[] basePageModels, bool animate = true)
+		{
+			throw new NotImplementedException();
+		}
+
+		public Task PushNewNavigationServiceModal(FreshTabbedNavigationContainer tabbedNavigationContainer, FreshBasePageModel basePageModel = null, bool animate = true)
+		{
+			throw new NotImplementedException();
+		}
+
+		public Task PushNewNavigationServiceModal(FreshMasterDetailNavigationContainer masterDetailContainer, FreshBasePageModel basePageModel = null, bool animate = true)
+		{
+			throw new NotImplementedException();
+		}
+
+		public Task PushNewNavigationServiceModal(IFreshNavigationService newNavigationService, FreshBasePageModel basePageModels, bool animate = true)
 		{
 			throw new NotImplementedException();
 		}
@@ -90,29 +136,78 @@ namespace FreshMvvm.Tests.Mocks
 			throw new NotImplementedException();
 		}
 
-        public Task PushNewNavigationServiceModal (IFreshNavigationService newNavigationService, FreshBasePageModel[] basePageModels)
-        {
-            throw new NotImplementedException ();
-        }
+		public Task PushPageModel<T>(object data, bool modal = false, bool animate = true) where T : FreshBasePageModel
+		{
+			throw new NotImplementedException();
+		}
 
-        public Task PopModalNavigationService ()
-        {
-            throw new NotImplementedException ();
-        }
+		public Task PushPageModel<T, TPage>(object data, bool modal = false, bool animate = true)
+			where T : FreshBasePageModel
+			where TPage : Page
+		{
+			throw new NotImplementedException();
+		}
 
-        public Task PushNewNavigationServiceModal (FreshTabbedNavigationContainer tabbedNavigationContainer)
-        {
-            throw new NotImplementedException ();
-        }
+		public Task PushPageModel<T>(bool animate = true) where T : FreshBasePageModel
+		{
+			throw new NotImplementedException();
+		}
 
-        public Task PushNewNavigationServiceModal (FreshMasterDetailNavigationContainer masterDetailContainer)
-        {
-            throw new NotImplementedException ();
-        }
+		public Task PushPageModel<T, TPage>(bool animate = true)
+			where T : FreshBasePageModel
+			where TPage : Page
+		{
+			throw new NotImplementedException();
+		}
 
-        public Task PushNewNavigationServiceModal (IFreshNavigationService newNavigationService, FreshBasePageModel basePageModels)
-        {
-            throw new NotImplementedException ();
-        }
+		public Task PushPageModel(Type pageModelType, bool animate = true)
+		{
+			throw new NotImplementedException();
+		}
+
+		public Task PushPageModel<T, TPage>(object data, bool modal = false) where T : FreshBasePageModel where TPage : Xamarin.Forms.Page
+		{
+			throw new NotImplementedException();
+		}
+
+		public Task PushPageModel<T, TPage>() where T : FreshBasePageModel where TPage : Xamarin.Forms.Page
+		{
+			throw new NotImplementedException();
+		}
+
+		public Task<string> PushPageModelWithNewNavigation<T>(object data, bool animate = true) where T : FreshBasePageModel
+		{
+			throw new NotImplementedException();
+		}
+
+		public void RemoveFromNavigation()
+		{
+			throw new NotImplementedException();
+		}
+
+		public void RemoveFromNavigation<TPageModel>(bool removeAll = false) where TPageModel : FreshBasePageModel
+		{
+			throw new NotImplementedException();
+		}
+
+		public void SwitchOutRootNavigation(string navigationServiceName)
+		{
+			throw new NotImplementedException();
+		}
+
+		public Task<FreshBasePageModel> SwitchSelectedRootPageModel<T>() where T : FreshBasePageModel
+		{
+			throw new NotImplementedException();
+		}
+
+		public Task<FreshBasePageModel> SwitchSelectedTab<T>() where T : FreshBasePageModel
+		{
+			throw new NotImplementedException();
+		}
+
+		public Task<FreshBasePageModel> SwitchSelectedMaster<T>() where T : FreshBasePageModel
+		{
+			throw new NotImplementedException();
+		}
 	}
 }


### PR DESCRIPTION
To get the FreshMvvm.Tests project to build:

**Added missing IPageModelCoreMethods method implementations to:**
FreshMvvm\Tests\MockPageModelCoreMethods.cs 

These new methods just throw the default not implemented exception like the other methods in the class.
`throw new NotImplementedExcetpion(); `

**No changes to FreshMvvm Core.**

**FreshMvvmSampleApp.iOS**
I was also unable to commit w/o the iOS sample project's .csproj file from updating:
<AssemblyName>FreshMvvmSampleApp.iOS</AssemblyName>
to
<AssemblyName>FreshMvvmSampleAppiOS</AssemblyName>

This is because FreshMvvmSampleApp.iOS defines the assembly name as "FreshMvvmSampleAppiOS", not sure why this wasn't already picked up by the csproj file.

As this is my first contribution to the repository, I wanted to provide a small change, non-intrusive, but still beneficial.  I look forward to providing contributions to FreshMvvm in the future, and please feel free to provide feedback if I missed the mark on etiquette, conventions, process, etc.