### PR TITLE
Fixes issue 104 (https://github.com/rid00z/FreshMvvm/issues/104)

### DIFF
--- a/src/FreshMvvm/PageModelCoreMethods.cs
+++ b/src/FreshMvvm/PageModelCoreMethods.cs
@@ -260,16 +260,23 @@ namespace FreshMvvm
         /// </summary>
         public void RemoveFromNavigation<TPageModel> (bool removeAll = false) where TPageModel : FreshBasePageModel
         {
-            //var pages = this._currentPage.Navigation.Where (o => o is TPageModel);
-            foreach (var page in this._currentPage.Navigation.NavigationStack.Reverse().ToList()) 
+            FreshBasePageModel next = null;
+            foreach (var page in this._currentPage.Navigation.NavigationStack.Reverse().ToList())
             {
                 if (page.BindingContext is TPageModel) 
                 {
                     page.GetModel()?.RaisePageWasPopped ();
                     this._currentPage.Navigation.RemovePage (page);
+
+                    bool isPreviousPageModelMatch = typeof(TPageModel) == next?.PreviousPageModel?.GetType();
+                    if (isPreviousPageModelMatch)
+                    {
+                        next.PreviousPageModel = next.PreviousPageModel?.PreviousPageModel;
+                    }
                     if (!removeAll)
                         break;
                 }
+                next = next == null ? _currentPageModel : next.PreviousPageModel;
             }
         }
     }


### PR DESCRIPTION
Fixes issue 104:  RemoveFromNavigation and then popping PageModel causes ReverseInit being called on removed FreshBasePageModel, instead of the one being popped.