### PR TITLE
Bug101: Allow checks against TinyIOC for CanResolve<>

### DIFF
--- a/src/FreshMvvm/FreshTinyIOCBuiltIn.cs
+++ b/src/FreshMvvm/FreshTinyIOCBuiltIn.cs
@@ -57,6 +57,23 @@ namespace FreshMvvm
         {
             FreshTinyIoCContainer.Current.Unregister<RegisterType>(name);
         }
+
+        public bool CanResolve(Type resolveType)
+        {
+            return FreshTinyIoCContainer.Current.CanResolve(resolveType);
+        }
+
+        public bool CanResolve<RegisterType>()
+            where RegisterType : class
+        {
+            return FreshTinyIoCContainer.Current.CanResolve<RegisterType>();
+        }
+
+        public bool CanResolve<RegisterType>(string name)
+            where RegisterType : class
+        {
+            return FreshTinyIoCContainer.Current.CanResolve<RegisterType>(name);
+        }
     }
 }
 


### PR DESCRIPTION
Exposes the existing TinyIOC code for CanResolve<>. 
Mirrored the overloads that were already being used in the Fresh wrapper, but others exist within TinyIOC if needed.