### PR TITLE
FreshAwaitCommand now support canExecute Function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -194,3 +194,4 @@ FakesAssemblies/
 
 # Visual Studio 6 workspace options file
 *.opt
+/samples/FreshMvvmSampleApp/Droid/FreshMvvmSampleApp.Droid.csproj.bak

--- a/samples/FreshMvvmSampleApp/Droid/FreshMvvmSampleApp.Droid.csproj
+++ b/samples/FreshMvvmSampleApp/Droid/FreshMvvmSampleApp.Droid.csproj
@@ -15,7 +15,7 @@
     <AndroidApplication>True</AndroidApplication>
     <AndroidUseLatestPlatformSdk>True</AndroidUseLatestPlatformSdk>
     <AssemblyName>FreshMvvmSampleApp.Droid</AssemblyName>
-    <TargetFrameworkVersion>v6.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v8.0</TargetFrameworkVersion>
     <ReleaseVersion>2.2.0</ReleaseVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/samples/FreshMvvmSampleApp/FreshMvvmSampleApp.UWP/FreshMvvmSampleApp.UWP.csproj
+++ b/samples/FreshMvvmSampleApp/FreshMvvmSampleApp.UWP/FreshMvvmSampleApp.UWP.csproj
@@ -11,7 +11,7 @@
     <AssemblyName>FreshMvvmSampleApp.UWP</AssemblyName>
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
-    <TargetPlatformVersion>10.0.10586.0</TargetPlatformVersion>
+    <TargetPlatformVersion>10.0.16299.0</TargetPlatformVersion>
     <TargetPlatformMinVersion>10.0.10240.0</TargetPlatformMinVersion>
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <FileAlignment>512</FileAlignment>

--- a/src/FreshMvvm/FreshAwaitCommand.cs
+++ b/src/FreshMvvm/FreshAwaitCommand.cs
@@ -7,69 +7,115 @@ namespace FreshMvvm
     /// <summary>
     /// FreshAwaitCommand is designed to avoid the double tap issue in Xamarin.Forms for Android,
     /// in Xamarin.Forms it's a common issue that double taps on command would open the same window multiple times.
-    /// 
+    ///
     /// This command awaits TaskCompletionSource before allowing anymore of the command to execute.
-    /// 
-    /// NB* You must call the SetResult on the TaskCompletionSource otherwise this command will wait forever. 
+    ///
+    /// NB* You must call the SetResult on the TaskCompletionSource otherwise this command will wait forever.
     /// </summary>
     public class FreshAwaitCommand : ICommand
     {
-        Action<object, TaskCompletionSource<object>> _execute;
-        volatile bool _canExecute = true;
+        private readonly Func<object, bool> _canExecute;
+
+        private readonly Action<object, TaskCompletionSource<bool>> _execute;
+
+        private volatile bool _inProgress = false;
 
         /// <summary>
-        /// NB* This command waits until you call SetResult on the TaskCompletionSource. The return 
+        /// NB* This command waits until you call SetResult on the TaskCompletionSource. The return
         /// value on the TaskCompletionSource is not used.
         /// </summary>
         /// <param name="execute">Execute.</param>
-        public FreshAwaitCommand(Action<object, TaskCompletionSource<object>> execute)
+        public FreshAwaitCommand(Action<object, TaskCompletionSource<bool>> execute)
+        {
+            _execute = execute ?? throw new ArgumentNullException(nameof(execute));
+        }
+
+        /// <summary>
+        /// NB* This command waits until you call SetResult on the TaskCompletionSource. The return
+        /// value on the TaskCompletionSource is not used.
+        /// </summary>
+        /// <param name="execute">Execute.</param>
+        public FreshAwaitCommand(Action<TaskCompletionSource<bool>> execute) : this((o, tcs) => execute(tcs))
         {
             if (execute == null)
             {
                 throw new ArgumentNullException(nameof(execute));
             }
-
-            _execute = execute;
         }
 
-        public event EventHandler CanExecuteChanged;
+        /// <summary>
+        /// NB* This command waits until you call SetResult on the TaskCompletionSource. The return
+        /// value on the TaskCompletionSource is not used.
+        /// </summary>
+        /// <param name="execute">Execute.</param>
+        public FreshAwaitCommand(Action<object, TaskCompletionSource<bool>> execute, Func<object, bool> canExecute) : this(execute)
+        {
+            _canExecute = canExecute ?? throw new ArgumentNullException(nameof(canExecute));
+        }
+
+        /// <summary>
+        /// NB* This command waits until you call SetResult on the TaskCompletionSource. The return
+        /// value on the TaskCompletionSource is not used.
+        /// </summary>
+        /// <param name="execute">Execute.</param>
+        public FreshAwaitCommand(Action<TaskCompletionSource<bool>> execute, Func<bool> canExecute) : this((o, tcs) => execute(tcs), o => canExecute())
+        {
+            if (execute == null)
+            {
+                throw new ArgumentNullException(nameof(execute));
+            }
+            if (canExecute == null)
+            {
+                throw new ArgumentNullException(nameof(canExecute));
+            }
+        }
 
         public bool CanExecute(object parameter)
         {
-            return _canExecute;
+            if (_inProgress)
+            {
+                return false;
+            }
+            if (_canExecute != null)
+            {
+                return _canExecute(parameter);
+            }
+            return true;
         }
+
+        public event EventHandler CanExecuteChanged;
 
         public async void Execute(object parameter)
         {
             try
             {
-                _canExecute = false;
-                RaiseCanExecuteChanged();
-                TaskCompletionSource<object> tcs = new TaskCompletionSource<object>();
+                _inProgress = true;
+                ChangeCanExecute();
+
+                var tcs = new TaskCompletionSource<bool>();
+
                 _execute(parameter, tcs);
+
                 await tcs.Task;
             }
             finally
             {
-                _canExecute = true;
-                RaiseCanExecuteChanged();
+                _inProgress = false;
+                ChangeCanExecute();
             }
         }
 
-        public void RaiseCanExecuteChanged()
+        public void ChangeCanExecute()
         {
-            var handler = CanExecuteChanged;
-            if (handler != null)
+            try
             {
-                try
-                {
-                    handler(this, EventArgs.Empty);
-                }
-                catch (Exception)
-                {
-                }
+                var changed = CanExecuteChanged;
+
+                changed?.Invoke(this, EventArgs.Empty);
+            }
+            catch
+            {
             }
         }
     }
 }
-


### PR DESCRIPTION
Only consider change in FreshAwaitCommand. overload the contractor with canExecute function for more flexibility. 