### PR TITLE
Remove the count check-up

### DIFF
--- a/src/FreshMvvm/FreshBaseContentPage.cs
+++ b/src/FreshMvvm/FreshBaseContentPage.cs
@@ -16,7 +16,7 @@ namespace FreshMvvm
 
             var pageModel = BindingContext as FreshBasePageModel;
 
-            if (pageModel != null && pageModel.ToolbarItems != null && pageModel.ToolbarItems.Count > 0) {
+            if (pageModel != null && pageModel.ToolbarItems != null) {
 
                 pageModel.ToolbarItems.CollectionChanged += PageModel_ToolbarItems_CollectionChanged;
 


### PR DESCRIPTION
This will allow adding a ToolbarItem in Init() function of a PageModel if ToolbarItems are initialized in the PageModel constructor