### PR TITLE
Add non-generic IPageModelCoreMethods.RemoveFromNavigation method

### DIFF
--- a/src/FreshMvvm/IPageModelCoreMethods.cs
+++ b/src/FreshMvvm/IPageModelCoreMethods.cs
@@ -39,6 +39,13 @@ namespace FreshMvvm
         void RemoveFromNavigation<TPageModel> (bool removeAll = false) where TPageModel : FreshBasePageModel;
 
         /// <summary>
+        /// Removes specific page/pagemodel from navigation
+        /// </summary>
+        /// <param name="removeAll">Will remove all, otherwise it will just remove first on from the top of the stack</param>
+        /// <param name="type">The 1st type parameter</param>
+        void RemoveFromNavigation (Type type, bool removeAll = false);
+
+        /// <summary>
         /// This method pushes a new PageModel modally with a new NavigationContainer
         /// </summary>
         /// <returns>Returns the name of the new service</returns>

--- a/src/FreshMvvm/PageModelCoreMethods.cs
+++ b/src/FreshMvvm/PageModelCoreMethods.cs
@@ -258,12 +258,17 @@ namespace FreshMvvm
         /// <summary>
         /// Removes specific page/pagemodel from navigation
         /// </summary>
-        public void RemoveFromNavigation<TPageModel> (bool removeAll = false) where TPageModel : FreshBasePageModel
+        public void RemoveFromNavigation<TPageModel> (bool removeAll = false) where TPageModel : FreshBasePageModel =>
+            RemoveFromNavigation (typeof(TPageModel), removeAll);
+
+        /// <summary>
+        /// Removes specific page/pagemodel from navigation
+        /// </summary>
+        public void RemoveFromNavigation (Type type, bool removeAll = false)
         {
-            //var pages = this._currentPage.Navigation.Where (o => o is TPageModel);
             foreach (var page in this._currentPage.Navigation.NavigationStack.Reverse().ToList()) 
             {
-                if (page.BindingContext is TPageModel) 
+                if (page.BindingContext?.GetType() == type) 
                 {
                     page.GetModel()?.RaisePageWasPopped ();
                     this._currentPage.Navigation.RemovePage (page);


### PR DESCRIPTION
With this request, I suggest adding a non-generic version of `IPageModelCoreMethods.RemoveFromNavigation` accepting `Type` as a parameter.
This is useful in the situation when a developer needs to remove pages/viewmodels from the navigation stack, but he is not aware (he does not care) about their types in advance and gets it in runtime (for example, by enumerating the navigation stack).