### PR TITLE
PageModelCoreMethods incorrectly passes animate parameter to PopPage

### DIFF
--- a/src/FreshMvvm/PageModelCoreMethods.cs
+++ b/src/FreshMvvm/PageModelCoreMethods.cs
@@ -207,7 +207,7 @@ namespace FreshMvvm
 
             var navServiceName = _currentPageModel.PreviousNavigationServiceName;
             IFreshNavigationService rootNavigation = FreshIOC.Container.Resolve<IFreshNavigationService> (navServiceName);
-            await rootNavigation.PopPage (animate);
+            await rootNavigation.PopPage (true, animate);
         }
 
         /// <summary>


### PR DESCRIPTION
`PopModalNavigationService` is incorrectly passing `animate ` parameter as `modal`. This crashes, if called with true `PopModalNavigationService(animate = false)`

If I understand it correctly, PopModalNavigationService should always PopPage as modal, but pass the `animate` parameter.